### PR TITLE
Add Mammotion integration skeleton

### DIFF
--- a/homeassistant/components/mammotion/__init__.py
+++ b/homeassistant/components/mammotion/__init__.py
@@ -1,0 +1,24 @@
+"""The Mammotion integration."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+PLATFORMS: list[Platform] = []
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Mammotion from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = {}
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a Mammotion config entry."""
+    hass.data[DOMAIN].pop(entry.entry_id, None)
+    return True

--- a/homeassistant/components/mammotion/config_flow.py
+++ b/homeassistant/components/mammotion/config_flow.py
@@ -1,0 +1,36 @@
+"""Config flow for the Mammotion integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import DOMAIN
+
+
+class MammotionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Mammotion."""
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title=user_input[CONF_USERNAME], data=user_input
+            )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_USERNAME): str,
+                    vol.Required(CONF_PASSWORD): str,
+                }
+            ),
+        )

--- a/homeassistant/components/mammotion/const.py
+++ b/homeassistant/components/mammotion/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Mammotion integration."""
+
+DOMAIN = "mammotion"

--- a/homeassistant/components/mammotion/manifest.json
+++ b/homeassistant/components/mammotion/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "mammotion",
+  "name": "Mammotion",
+  "documentation": "https://github.com/mikey0000/Mammotion-HA/wiki",
+  "requirements": ["pymammotion==0.5.3"],
+  "codeowners": ["@mikey0000"],
+  "config_flow": true,
+  "iot_class": "local_push",
+  "integration_type": "device"
+}

--- a/homeassistant/components/mammotion/strings.json
+++ b/homeassistant/components/mammotion/strings.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        }
+      }
+    }
+  }
+}

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3219,3 +3219,6 @@ zwave-js-server-python==0.67.1
 
 # homeassistant.components.zwave_me
 zwave-me-ws==0.4.3
+
+# homeassistant.components.mammotion
+pymammotion==0.5.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2654,3 +2654,6 @@ zwave-js-server-python==0.67.1
 
 # homeassistant.components.zwave_me
 zwave-me-ws==0.4.3
+
+# homeassistant.components.mammotion
+pymammotion==0.5.3

--- a/tests/components/mammotion/test_config_flow.py
+++ b/tests/components/mammotion/test_config_flow.py
@@ -1,0 +1,14 @@
+"""Test the Mammotion config flow."""
+
+from homeassistant import config_entries
+from homeassistant.components.mammotion.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+
+async def test_user_init_form(hass: HomeAssistant) -> None:
+    """Test that the initial form is shown to the user."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM


### PR DESCRIPTION
## Summary
- scaffold Mammotion integration with basic config flow
- add `pymammotion` dependency placeholders
- add initial config flow test

## Testing
- `pre-commit run --files requirements_all.txt requirements_test_all.txt homeassistant/components/mammotion/__init__.py homeassistant/components/mammotion/const.py homeassistant/components/mammotion/config_flow.py homeassistant/components/mammotion/manifest.json homeassistant/components/mammotion/strings.json tests/components/mammotion/test_config_flow.py` *(fails: SyntaxError in hassfest)*
- `pytest tests/components/mammotion/test_config_flow.py -q` *(fails: ModuleNotFoundError: No module named 'atomicwrites')*

------
https://chatgpt.com/codex/tasks/task_e_689b56ec7cc88322b276135aedc17edc