### PR TITLE
Add Mammotion integration

### DIFF
--- a/homeassistant/components/mammotion/manifest.json
+++ b/homeassistant/components/mammotion/manifest.json
@@ -17,8 +17,10 @@
   "codeowners": ["@mikey0000"],
   "config_flow": true,
   "dependencies": ["bluetooth_adapters"],
+  "after_dependencies": ["http"],
   "documentation": "https://www.home-assistant.io/integrations/mammotion",
   "loggers": ["pymammotion"],
   "iot_class": "local_push",
+  "quality_scale": "bronze",
   "requirements": ["pymammotion==0.5.3"]
 }

--- a/homeassistant/components/mammotion/services.yaml
+++ b/homeassistant/components/mammotion/services.yaml
@@ -44,8 +44,8 @@ start_mow:
         select:
           translation_key: "border_mode"
           options:
-            - 0
-            - 1
+            - "0"
+            - "1"
     job_version:
       example: 0
       default: 0
@@ -76,11 +76,11 @@ start_mow:
         select:
           translation_key: "ultra_wave"
           options:
-            - 0
-            - 1
-            - 2
-            - 10
-            - 11
+            - "0"
+            - "1"
+            - "2"
+            - "10"
+            - "11"
       required: false
     channel_mode:
       example: 0
@@ -90,10 +90,10 @@ start_mow:
         select:
           translation_key: "channel_mode"
           options:
-            - 0
-            - 1
-            - 2
-            - 3
+            - "0"
+            - "1"
+            - "2"
+            - "3"
     channel_width:
       example: 25
       default: 25
@@ -110,8 +110,8 @@ start_mow:
         select:
           translation_key: "rain_tactics"
           options:
-            - 0
-            - 1
+            - "0"
+            - "1"
     blade_height:
       example: 0
       default: 25
@@ -147,9 +147,9 @@ start_mow:
         select:
           translation_key: "toward_mode"
           options:
-            - 0
-            - 1
-            - 2
+            - "0"
+            - "1"
+            - "2"
       required: false
     mowing_laps:
       example: 1
@@ -158,11 +158,11 @@ start_mow:
         select:
           translation_key: "mowing_laps"
           options:
-            - 0
-            - 1
-            - 2
-            - 3
-            - 4
+            - "0"
+            - "1"
+            - "2"
+            - "3"
+            - "4"
       required: false
     obstacle_laps:
       example: 1
@@ -171,11 +171,11 @@ start_mow:
         select:
           translation_key: "obstacle_laps"
           options:
-            - 0
-            - 1
-            - 2
-            - 3
-            - 4
+            - "0"
+            - "1"
+            - "2"
+            - "3"
+            - "4"
       required: false
     start_progress:
       example: 0

--- a/homeassistant/components/mammotion/strings.json
+++ b/homeassistant/components/mammotion/strings.json
@@ -276,7 +276,9 @@
       }
     },
     "device_tracker": {
-      "name": "Device Tracking"
+      "device_tracker": {
+        "name": "Device Tracking"
+      }
     }
   },
   "selector": {

--- a/tests/components/mammotion/test_config_flow.py
+++ b/tests/components/mammotion/test_config_flow.py
@@ -1,5 +1,7 @@
 """Test the Mammotion config flow."""
 
+from __future__ import annotations
+
 from homeassistant import config_entries
 from homeassistant.components.mammotion.const import DOMAIN
 from homeassistant.core import HomeAssistant


### PR DESCRIPTION
## Summary
- ensure Mammotion declares http dependency and bronze quality scale
- fix Mammotion service options and device tracker translations

## Testing
- `pytest tests/components/mammotion -q`
- `pre-commit run --files homeassistant/components/mammotion/manifest.json homeassistant/components/mammotion/services.yaml homeassistant/components/mammotion/strings.json` *(failed: certificate verify failed)*
- `python -m script.hassfest` *(failed: ImportError: cannot import name 'TurboJPEG')*

------
https://chatgpt.com/codex/tasks/task_e_689bf5e208bc83228a970761af2a82d8